### PR TITLE
Compatibility with `use strict`

### DIFF
--- a/u2f_polyfill.js
+++ b/u2f_polyfill.js
@@ -1,4 +1,4 @@
-(function(exports, global) {
+(function(global) {
     var pingerPonger = {
         pingPong: function() {
             this.whenReady_ = [];
@@ -55,7 +55,6 @@
     if (!global.u2f && !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform)) {
         global.u2f = new u2fClient();
     }
-    global[""] = exports;
-})({}, function() {
+})(function() {
     return this;
 }());

--- a/u2f_polyfill.js
+++ b/u2f_polyfill.js
@@ -1,4 +1,7 @@
 (function(global) {
+    if (global.u2f || !navigator.platform || !/iPad|iPhone|iPod/.test(navigator.platform)) {
+        return;
+    }
     var pingerPonger = {
         pingPong: function() {
             this.whenReady_ = [];
@@ -52,7 +55,5 @@
             });
         };
     };
-    if (!global.u2f && !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform)) {
-        global.u2f = new u2fClient();
-    }
+    global.u2f = new u2fClient();
 })(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {});

--- a/u2f_polyfill.js
+++ b/u2f_polyfill.js
@@ -55,6 +55,4 @@
     if (!global.u2f && !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform)) {
         global.u2f = new u2fClient();
     }
-})(function() {
-    return this;
-}());
+})(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {});


### PR DESCRIPTION
In "strict" JS mode, the expression `function(){ return this }()` cannot be used to access the global object.

This file would be affected by strict mode if it were concatenated with another script that has `use strict`.